### PR TITLE
Potential fix for code scanning alert no. 14: Uncontrolled data used in path expression

### DIFF
--- a/templates/server.js
+++ b/templates/server.js
@@ -1129,17 +1129,25 @@ app.post("/api/upload/voice/:voiceId", require2FAMiddleware, multer().single('vo
 
 app.get("/api/download/:filename", (req, res) => {
     const filename = req.params.filename;
-    const filePath = path.join(config.uploads.dir, filename);
-
-    if (filename.includes('..') || filename.includes('/') || filename.includes('\\')) {
-        return res.status(400).json({ error: "invalid filename" });
+    // Build the absolute path to the file, normalize and resolve symlinks
+    let requestedPath;
+    try {
+        requestedPath = path.resolve(config.uploads.dir, filename);
+        requestedPath = fs.realpathSync(requestedPath);
+    } catch (e) {
+        return res.status(400).json({ error: "invalid filename or path" });
+    }
+    // Ensure the resolved path is under uploads directory
+    const uploadsDir = fs.realpathSync(config.uploads.dir);
+    if (!requestedPath.startsWith(uploadsDir + path.sep)) {
+        return res.status(403).json({ error: "forbidden" });
     }
 
-    if (fs.existsSync(filePath)) {
+    if (fs.existsSync(requestedPath)) {
         const originalName = storage.getOriginalFileName(filename);
         
         res.setHeader('Content-Disposition', `attachment; filename="${encodeURIComponent(originalName)}"`);
-        res.download(filePath, originalName);
+        res.download(requestedPath, originalName);
     } else {
         res.status(404).json({ success: false, error: "file not found" });
     }


### PR DESCRIPTION
Potential fix for [https://github.com/DUMBMessenger/DUMB/security/code-scanning/14](https://github.com/DUMBMessenger/DUMB/security/code-scanning/14)

To fix the problem robustly, we should use `path.resolve` (or `path.normalize` + `path.join`) to resolve the requested file path relative to the intended upload root directory (`config.uploads.dir`). After resolving, use `fs.realpathSync` (or `fs.promises.realpath`) to eliminate any remaining symlink or path manipulation opportunities. Finally, verify that the resolved path starts with the absolute path of the root directory; if not, deny access. Make sure to update both the existence check and the actual download call to use the validated, normalized full path. If the checks fail, respond with an error.

All changes should occur within the code for `/api/download/:filename` inside templates/server.js, lines 1130–1146. You will need to update the middleware for this route, potentially ensuring that the error handling and user file name retrieval still work correctly.

No new package is strictly needed in this case, as Node.js built-in modules suffice for path checking.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
