### PR TITLE
Potential fix for code scanning alert no. 10: Use of password hash with insufficient computational effort

### DIFF
--- a/templates/storage/slaves/sqls.js
+++ b/templates/storage/slaves/sqls.js
@@ -405,8 +405,8 @@ export async function authenticate(username, passwordPlain) {
     const check = pbkdf2(passwordPlain, u.salt);
     return check === u.passwordHash ? u.username : null;
   } else {
-    const check = sha256(passwordPlain);
-    return check === u.passwordHash ? u.username : null;
+    // Insecure password hash detected, refuse login
+    return null;
   }
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/DUMBMessenger/DUMB/security/code-scanning/10](https://github.com/DUMBMessenger/DUMB/security/code-scanning/10)

To fix the problem, remove all use of SHA256 for password hashing in the `authenticate` function. All passwords should be verified against hashes produced by a proper password hashing function such as PBKDF2, bcrypt, scrypt, or Argon2. Since PBKDF2 is already configured and in use for the main path (and there is code for it, and configs for iterations, digest, etc.), update the fallback logic to ensure that users created without a salt are migrated to the secure scheme when they next log in — or, at minimum, refuse authentication unless the password is hashed with PBKDF2 and a salt.

Modify the `authenticate` function so that:  
- The branch that uses SHA256 for password verification is eliminated.  
- If a user record does not have a salt, refuse login, or alternatively return a helpful error/message noting the need to reset password (for onward migration).  
- Optionally, provide a migration path in-register and authentication logic (but only within the snippet shown, you should block login for unsalted users).

No additional methods or imports are required, as PBKDF2 is already available and used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
